### PR TITLE
Implement support for enumerating delimited substrings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*.*.*'
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
 
 jobs:
@@ -39,8 +37,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
-      - name: 'Run: Test, ValidateFormat, Pack, ValidatePackages'
-        run: ./build.cmd Test ValidateFormat Pack ValidatePackages
+      - name: 'Run: Test, ValidateFormat, Pack, ValidatePackages, Publish'
+        run: ./build.cmd Test ValidateFormat Pack ValidatePackages Publish
       - name: 'Publish: test-results'
         uses: actions/upload-artifact@v3
         if: ${{ runner.os == 'Windows' }}
@@ -67,8 +65,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
-      - name: 'Run: Test, ValidateFormat, Pack, ValidatePackages'
-        run: ./build.cmd Test ValidateFormat Pack ValidatePackages
+      - name: 'Run: Test, ValidateFormat, Pack, ValidatePackages, Publish'
+        run: ./build.cmd Test ValidateFormat Pack ValidatePackages Publish
       - name: 'Publish: test-results'
         uses: actions/upload-artifact@v3
         if: ${{ runner.os == 'Windows' }}
@@ -95,8 +93,8 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
-      - name: 'Run: Test, ValidateFormat, Pack, ValidatePackages'
-        run: ./build.cmd Test ValidateFormat Pack ValidatePackages
+      - name: 'Run: Test, ValidateFormat, Pack, ValidatePackages, Publish'
+        run: ./build.cmd Test ValidateFormat Pack ValidatePackages Publish
       - name: 'Publish: test-results'
         uses: actions/upload-artifact@v3
         if: ${{ runner.os == 'Windows' }}

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -30,10 +30,6 @@
           "type": "string",
           "default": "Secrets must be entered via 'nuke :secrets [profile]'"
         },
-        "GitHubRepositoryOwner": {
-          "type": "string",
-          "description": "Owner of the repository"
-        },
         "Help": {
           "type": "boolean",
           "description": "Shows the help text for this build assembly"
@@ -66,6 +62,10 @@
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
+        },
+        "PackageOwner": {
+          "type": "string",
+          "description": "Owner of the package"
         },
         "Partition": {
           "type": "string",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Add support for various enumerators for enumerating delimited substrings in strings without allocating additional strings.
 
 ## [0.1.0] / 2023-11-08
 - Initial release

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatchTag
 assembly-informational-format: '{SemVer}+{BranchName}.{ShortSha}'
-next-version: 0.1.0
+next-version: 0.2.0
 branches: {}
 ignore:
   sha: []

--- a/build/Build.GithubActions.cs
+++ b/build/Build.GithubActions.cs
@@ -34,12 +34,18 @@ using System.Collections.Generic;
     GitHubActionsImage.UbuntuLatest,
     GitHubActionsImage.MacOsLatest,
     OnPushBranches = new[] { MainBranch },
-    OnPushTags = new[] { "*.*.*" },
     PublishArtifacts = true,
     PublishCondition = "${{ runner.os == 'Windows' }}",
     EmptyWorkflowTrigger = true,
     FetchDepth = 0, // fetch full history
-    InvokedTargets = new[] { nameof(ITest.Test), nameof(ValidateFormat), nameof(IPack.Pack), nameof(ValidatePackages) }
+    InvokedTargets = new[]
+    {
+        nameof(ITest.Test),
+        nameof(ValidateFormat),
+        nameof(IPack.Pack),
+        nameof(ValidatePackages),
+        nameof(IPublish.Publish),
+    }
     )]
 public partial class Build
 {

--- a/examples/SpanUtils.ChunksExample/Program.cs
+++ b/examples/SpanUtils.ChunksExample/Program.cs
@@ -10,9 +10,37 @@ int[][] expectedChunks = new[]
     new[] { 4, 5 },
 };
 
-int index = 0;
-foreach (Span<int> chunk in data.GetChunksEnumerator(chunkSize, exact: true))
 {
-    Debug.Assert(chunk.SequenceEqual(expectedChunks[index]));
-    ++index;
+    int index = 0;
+    foreach (Span<int> chunk in data.GetChunksEnumerator(chunkSize, exact: true))
+    {
+        Debug.Assert(chunk.SequenceEqual(expectedChunks[index]));
+        ++index;
+    }
+}
+{
+    int index = 0;
+    foreach (ReadOnlySpan<int> chunk in data.GetReadOnlyChunksEnumerator(chunkSize, exact: true))
+    {
+        Debug.Assert(chunk.SequenceEqual(expectedChunks[index]));
+        ++index;
+    }
+}
+{
+    Span<int> dataSpan = data;
+    int index = 0;
+    foreach (ReadOnlySpan<int> chunk in dataSpan.GetReadOnlyChunksEnumerator(chunkSize, exact: true))
+    {
+        Debug.Assert(chunk.SequenceEqual(expectedChunks[index]));
+        ++index;
+    }
+}
+{
+    ReadOnlySpan<int> readOnlyDataSpan = data;
+    int index = 0;
+    foreach (ReadOnlySpan<int> chunk in readOnlyDataSpan.GetReadOnlyChunksEnumerator(chunkSize, exact: true))
+    {
+        Debug.Assert(chunk.SequenceEqual(expectedChunks[index]));
+        ++index;
+    }
 }

--- a/src/SpanUtils/Enumerators/ReadOnlySpanChunk.cs
+++ b/src/SpanUtils/Enumerators/ReadOnlySpanChunk.cs
@@ -23,11 +23,19 @@ public readonly ref struct ReadOnlySpanChunk<T>
     /// </summary>
     public int Index { get; }
 
+    /// <summary>
+    /// Deconstruct this
+    /// </summary>
+    /// <param name="span">The current span</param>
+    /// <param name="index">The current index</param>
     public void Deconstruct(out ReadOnlySpan<T> span, out int index)
     {
         span = Span;
         index = Index;
     }
 
+    /// <summary>
+    /// Support implicit conversion
+    /// </summary>
     public static implicit operator ReadOnlySpan<T>(ReadOnlySpanChunk<T> entry) => entry.Span;
 }

--- a/src/SpanUtils/Enumerators/ReadOnlySpanChunksEnumerator.cs
+++ b/src/SpanUtils/Enumerators/ReadOnlySpanChunksEnumerator.cs
@@ -33,16 +33,31 @@ public ref struct ReadOnlySpanChunksEnumerator<T>
         _index = 0;
     }
 
-    // Needed to be compatible with the foreach operator
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
     public readonly ReadOnlySpanChunksEnumerator<T> GetEnumerator() => this;
 
+    /// <summary>
+    /// Gets the current chunk
+    /// </summary>
     public ReadOnlySpanChunk<T> Current { get; private set; }
 
+    /// <summary>
+    /// Resets this enumerator
+    /// </summary>
     public void Reset()
     {
         _index = 0;
     }
 
+    /// <summary>
+    /// Advances the enumerator to the next chunk in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next chunk; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
     public bool MoveNext()
     {
         var span = _span;

--- a/src/SpanUtils/Enumerators/ReadOnlySpanReverseEnumerator.cs
+++ b/src/SpanUtils/Enumerators/ReadOnlySpanReverseEnumerator.cs
@@ -18,18 +18,39 @@ public ref struct ReadOnlySpanReverseEnumerator<T>
     {
         _span = span;
         _index = _span.Length;
+        Current = default!;
     }
 
-    // Needed to be compatible with the foreach operator
+    /// <summary>
+    /// Returns the length of the original span
+    /// </summary>
+    public readonly int Length => _span.Length;
+
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
     public readonly ReadOnlySpanReverseEnumerator<T> GetEnumerator() => this;
 
-    public T Current { get; private set; } = default!;
+    /// <summary>
+    /// Gets the current value
+    /// </summary>
+    public T Current { get; private set; }
 
+    /// <summary>
+    /// Resets this enumerator
+    /// </summary>
     public void Reset()
     {
         _index = _span.Length;
     }
 
+    /// <summary>
+    /// Advances the enumerator to the next element in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next element; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
     public bool MoveNext()
     {
         var next = --_index;

--- a/src/SpanUtils/Enumerators/ReadOnlySpanSelectEnumerator.cs
+++ b/src/SpanUtils/Enumerators/ReadOnlySpanSelectEnumerator.cs
@@ -24,25 +24,39 @@ public ref struct ReadOnlySpanSelectEnumerator<T, U>
         _span = span;
         _index = -1;
         _selector = selector;
+        Current = default!;
     }
 
-#if NETSTANDARD2_0_OR_GREATER || NET6_0_OR_GREATER
+    /// <summary>
+    /// Returns the length of the original span
+    /// </summary>
     public readonly int Length => _span.Length;
 
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
     public readonly ReadOnlySpanSelectEnumerator<T, U> GetEnumerator() => this;
-#else
-    public int Length => _span.Length;
 
-    public ReadOnlySpanSelectEnumerator<T, U> GetEnumerator() => this;
-#endif
+    /// <summary>
+    /// Gets the current value
+    /// </summary>
+    public U Current { get; private set; }
 
-    public U Current { get; private set; } = default!;
-
+    /// <summary>
+    /// Resets this enumerator
+    /// </summary>
     public void Reset()
     {
         _index = -1;
     }
 
+    /// <summary>
+    /// Advances the enumerator to the next element in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next element; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
     public bool MoveNext()
     {
         var next = _index + 1;

--- a/src/SpanUtils/Enumerators/ReadOnlySpanWindow.cs
+++ b/src/SpanUtils/Enumerators/ReadOnlySpanWindow.cs
@@ -12,6 +12,9 @@ public readonly ref struct ReadOnlySpanWindow<T>
     /// </summary>
     public ReadOnlySpan<T> Span { get; }
 
+    /// <summary>
+    /// Index of the first element of this window inside the original span
+    /// </summary>
     public int Index { get; }
 
     internal ReadOnlySpanWindow(ReadOnlySpan<T> span, int index)
@@ -20,11 +23,19 @@ public readonly ref struct ReadOnlySpanWindow<T>
         Index = index;
     }
 
+    /// <summary>
+    /// Deconstruct this
+    /// </summary>
+    /// <param name="span">The current span</param>
+    /// <param name="index">The current index</param>
     public void Deconstruct(out ReadOnlySpan<T> span, out int index)
     {
         span = Span;
         index = Index;
     }
 
+    /// <summary>
+    /// Support implicit conversion
+    /// </summary>
     public static implicit operator ReadOnlySpan<T>(ReadOnlySpanWindow<T> entry) => entry.Span;
 }

--- a/src/SpanUtils/Enumerators/ReadOnlySpanWindowsEnumerator.cs
+++ b/src/SpanUtils/Enumerators/ReadOnlySpanWindowsEnumerator.cs
@@ -23,16 +23,31 @@ public ref struct ReadOnlySpanWindowsEnumerator<T>
         _span = span;
     }
 
-    // Needed to be compatible with the foreach operator
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
     public readonly ReadOnlySpanWindowsEnumerator<T> GetEnumerator() => this;
 
+    /// <summary>
+    /// Gets the current window
+    /// </summary>
     public ReadOnlySpanWindow<T> Current { get; private set; }
 
+    /// <summary>
+    /// Resets this enumerator
+    /// </summary>
     public void Reset()
     {
         _index = 0;
     }
 
+    /// <summary>
+    /// Advances the enumerator to the next window in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next window; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
     public bool MoveNext()
     {
         var span = _span;

--- a/src/SpanUtils/Enumerators/SpanChunk.cs
+++ b/src/SpanUtils/Enumerators/SpanChunk.cs
@@ -23,12 +23,24 @@ public readonly ref struct SpanChunk<T>
     /// </summary>
     public int Index { get; }
 
+    /// <summary>
+    /// Deconstruct this
+    /// </summary>
+    /// <param name="span">The current span</param>
+    /// <param name="index">The current index</param>
     public void Deconstruct(out Span<T> span, out int index)
     {
         span = Span;
         index = Index;
     }
 
+    /// <summary>
+    /// Support implicit conversion
+    /// </summary>
     public static implicit operator Span<T>(SpanChunk<T> entry) => entry.Span;
+
+    /// <summary>
+    /// Support implicit conversion
+    /// </summary>
     public static implicit operator ReadOnlySpan<T>(SpanChunk<T> entry) => entry.Span;
 }

--- a/src/SpanUtils/Enumerators/SpanChunksEnumerator.cs
+++ b/src/SpanUtils/Enumerators/SpanChunksEnumerator.cs
@@ -33,16 +33,31 @@ public ref struct SpanChunksEnumerator<T>
         _span = span;
     }
 
-    // Needed to be compatible with the foreach operator
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
     public readonly SpanChunksEnumerator<T> GetEnumerator() => this;
 
+    /// <summary>
+    /// Gets the current chunk
+    /// </summary>
     public SpanChunk<T> Current { get; private set; }
 
+    /// <summary>
+    /// Resets this enumerator
+    /// </summary>
     public void Reset()
     {
         _index = 0;
     }
 
+    /// <summary>
+    /// Advances the enumerator to the next chunk in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next chunk; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
     public bool MoveNext()
     {
         var span = _span;

--- a/src/SpanUtils/Enumerators/SpanReverseEnumerator.cs
+++ b/src/SpanUtils/Enumerators/SpanReverseEnumerator.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace SpanUtils.Enumerators;
 
 #if NET7_0_OR_GREATER
+using System.Runtime.CompilerServices;
 
 /// <summary>
 /// Enumerate contents of a <see cref="Span{T}"/> in reverse.
@@ -25,16 +25,31 @@ public ref struct SpanReverseEnumerator<T>
         _current = ref Unsafe.NullRef<T>();
     }
 
-    // Needed to be compatible with the foreach operator
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
     public readonly SpanReverseEnumerator<T> GetEnumerator() => this;
 
+    /// <summary>
+    /// Gets the current value
+    /// </summary>
     public ref T Current => ref _current;
 
+    /// <summary>
+    /// Resets this enumerator
+    /// </summary>
     public void Reset()
     {
         _index = _span.Length;
     }
 
+    /// <summary>
+    /// Advances the enumerator to the next element in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next element; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
     public bool MoveNext()
     {
         var next = --_index;
@@ -68,19 +83,34 @@ public ref struct SpanReverseEnumerator<T>
     {
         _span = span;
         _index = _span.Length;
+        Current = default!;
     }
 
-    // Needed to be compatible with the foreach operator
-
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
     public readonly SpanReverseEnumerator<T> GetEnumerator() => this;
 
-    public T Current { get; private set; } = default!;
+    /// <summary>
+    /// Gets the current value
+    /// </summary>
+    public T Current { get; private set; }
 
+    /// <summary>
+    /// Resets this enumerator
+    /// </summary>
     public void Reset()
     {
         _index = _span.Length;
     }
 
+    /// <summary>
+    /// Advances the enumerator to the next element in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next element; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
     public bool MoveNext()
     {
         var next = --_index;

--- a/src/SpanUtils/Enumerators/SpanWindow.cs
+++ b/src/SpanUtils/Enumerators/SpanWindow.cs
@@ -23,12 +23,24 @@ public readonly ref struct SpanWindow<T>
         Index = index;
     }
 
+    /// <summary>
+    /// Deconstruct this
+    /// </summary>
+    /// <param name="span">The current span</param>
+    /// <param name="index">The current index</param>
     public void Deconstruct(out Span<T> span, out int index)
     {
         span = Span;
         index = Index;
     }
 
+    /// <summary>
+    /// Support implicit conversion
+    /// </summary>
     public static implicit operator Span<T>(SpanWindow<T> entry) => entry.Span;
+
+    /// <summary>
+    /// Support implicit conversion
+    /// </summary>
     public static implicit operator ReadOnlySpan<T>(SpanWindow<T> entry) => entry.Span;
 }

--- a/src/SpanUtils/Enumerators/SpanWindowsEnumerator.cs
+++ b/src/SpanUtils/Enumerators/SpanWindowsEnumerator.cs
@@ -23,16 +23,31 @@ public ref struct SpanWindowsEnumerator<T>
         _index = 0;
     }
 
-    // Needed to be compatible with the foreach operator
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
     public readonly SpanWindowsEnumerator<T> GetEnumerator() => this;
 
+    /// <summary>
+    /// Gets the current window
+    /// </summary>
     public SpanWindow<T> Current { get; private set; }
 
+    /// <summary>
+    /// Resets this enumerator
+    /// </summary>
     public void Reset()
     {
         _index = 0;
     }
 
+    /// <summary>
+    /// Advances the enumerator to the next window in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next window; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
     public bool MoveNext()
     {
         var span = _span;

--- a/src/SpanUtils/Enumerators/StringSplitByCharArrayEnumerator.cs
+++ b/src/SpanUtils/Enumerators/StringSplitByCharArrayEnumerator.cs
@@ -1,0 +1,80 @@
+﻿using System;
+
+namespace SpanUtils.Enumerators;
+
+/// <summary>
+/// Enumerates substrings of a <see cref="ReadOnlySpan{Char}"/> separated by specified delimiting characters and options.
+/// </summary>
+/// <remarks>
+/// To get an instance of this type, use <see cref="Extensions.StringExtensions.EnumerateSplitSubstrings(ReadOnlySpan{char}, char[], StringSplitOptions)"/>.
+/// </remarks>
+public ref struct StringSplitByCharArrayEnumerator
+{
+    private readonly ReadOnlySpan<char> _sep;
+    private readonly StringSplitOptions _options;
+
+    private ReadOnlySpan<char> _remaining;
+    private bool _yieldEmpty;
+
+    internal StringSplitByCharArrayEnumerator(
+        ReadOnlySpan<char> str,
+        char[] sep,
+        StringSplitOptions options)
+    {
+        _sep = sep is null || sep.Length == 0
+            ? (ReadOnlySpan<char>)StringSplitUtils.WhitespaceChars
+            : (ReadOnlySpan<char>)sep;
+        _options = options;
+        _remaining = str;
+        _yieldEmpty = false;
+        Current = default;
+    }
+
+    /// <summary>
+    /// Gets the current substring
+    /// </summary>
+    public ReadOnlySpan<char> Current { get; private set; }
+
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
+    public readonly StringSplitByCharArrayEnumerator GetEnumerator() => this;
+
+    /// <summary>
+    /// Advances the enumerator to the next substring in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next substring; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
+    public bool MoveNext()
+    {
+        var span = _remaining;
+        var sep = _sep;
+        var options = _options;
+        var empty = _yieldEmpty;
+
+        while (StringSplitUtils.TryMoveNext(
+            ref span,
+            ref empty,
+            span.IndexOfAny(sep),
+            1,
+            options,
+            out var next))
+        {
+            if (_options.HasFlag(StringSplitOptions.RemoveEmptyEntries) && next.IsEmpty)
+            {
+                continue;
+            }
+
+            Current = next;
+            _yieldEmpty = empty;
+            _remaining = span;
+            return true;
+        }
+
+        _yieldEmpty = empty;
+        _remaining = span;
+        return false;
+    }
+}

--- a/src/SpanUtils/Enumerators/StringSplitByCharEnumerator.cs
+++ b/src/SpanUtils/Enumerators/StringSplitByCharEnumerator.cs
@@ -1,0 +1,77 @@
+﻿using System;
+
+namespace SpanUtils.Enumerators;
+
+/// <summary>
+/// Enumerates substrings of a <see cref="ReadOnlySpan{Char}"/> separated by specified delimiting character and options.
+/// </summary>
+/// <remarks>
+/// To get an instance of this type, use <see cref="Extensions.StringExtensions.EnumerateSplitSubstrings(ReadOnlySpan{char}, char, StringSplitOptions)"/>.
+/// </remarks>
+public ref struct StringSplitByCharEnumerator
+{
+    private readonly char _sep;
+    private readonly StringSplitOptions _options;
+
+    private ReadOnlySpan<char> _remaining;
+    private bool _yieldEmpty;
+
+    internal StringSplitByCharEnumerator(
+        ReadOnlySpan<char> str,
+        char sep,
+        StringSplitOptions options)
+    {
+        _sep = sep;
+        _options = options;
+        _remaining = str;
+        _yieldEmpty = false;
+    }
+
+    /// <summary>
+    /// Gets the current substring
+    /// </summary>
+    public ReadOnlySpan<char> Current { get; private set; }
+
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
+    public readonly StringSplitByCharEnumerator GetEnumerator() => this;
+
+    /// <summary>
+    /// Advances the enumerator to the next substring in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next substring; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
+    public bool MoveNext()
+    {
+        var span = _remaining;
+        var sep = _sep;
+        var options = _options;
+        var empty = _yieldEmpty;
+
+        while (StringSplitUtils.TryMoveNext(
+            ref span,
+            ref empty,
+            span.IndexOf(sep),
+            1,
+            options,
+            out var next))
+        {
+            if (_options.HasFlag(StringSplitOptions.RemoveEmptyEntries) && next.IsEmpty)
+            {
+                continue;
+            }
+
+            Current = next;
+            _remaining = span;
+            _yieldEmpty = empty;
+            return true;
+        }
+
+        _yieldEmpty = empty;
+        _remaining = span;
+        return false;
+    }
+}

--- a/src/SpanUtils/Enumerators/StringSplitByLinesEnumerator.cs
+++ b/src/SpanUtils/Enumerators/StringSplitByLinesEnumerator.cs
@@ -1,0 +1,77 @@
+﻿using System;
+
+namespace SpanUtils.Enumerators;
+
+/// <summary>
+/// Enumerates the lines of a <see cref="ReadOnlySpan{Char}"/>.
+/// </summary>
+/// <remarks>
+/// To get an instance of this type, use <see cref="Extensions.StringExtensions.EnumerateSplitLines(ReadOnlySpan{char})"/>.
+/// </remarks>
+public ref struct StringSplitByLinesEnumerator
+{
+    private ReadOnlySpan<char> _remaining;
+    private bool _isDone;
+
+    internal StringSplitByLinesEnumerator(ReadOnlySpan<char> str)
+    {
+        _remaining = str;
+        _isDone = false;
+        Current = default;
+    }
+
+    /// <summary>
+    /// Gets the current line in the span.
+    /// </summary>
+    public ReadOnlySpan<char> Current { get; private set; }
+
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
+    public readonly StringSplitByLinesEnumerator GetEnumerator() => this;
+
+    /// <summary>
+    /// Advances the enumerator to the next line in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next line; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
+    public bool MoveNext()
+    {
+        if (_isDone)
+        {
+            return false;
+        }
+
+        var span = _remaining;
+        var len = span.Length;
+
+        var index = span.IndexOfAny(StringSplitUtils.NewlineChars);
+
+        if (index == -1)
+        {
+            // EOF
+            Current = span;
+            _remaining = default;
+            _isDone = true;
+        }
+        else
+        {
+            var step = 1;
+
+            // Check if we have CR + LF
+            if (span[index] == '\r' && index + 1 < len && span[index + 1] == '\n')
+            {
+                step = 2;
+            }
+
+#pragma warning disable IDE0057 // Use range operator
+            Current = span.Slice(0, index);
+            _remaining = span.Slice(index + step);
+#pragma warning restore IDE0057 // Use range operator
+        }
+
+        return true;
+    }
+}

--- a/src/SpanUtils/Enumerators/StringSplitByStringArrayEnumerator.cs
+++ b/src/SpanUtils/Enumerators/StringSplitByStringArrayEnumerator.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Linq;
+
+namespace SpanUtils.Enumerators;
+
+/// <summary>
+/// Enumerates substrings of a <see cref="ReadOnlySpan{Char}"/> separated by specified delimiting characters and options.
+/// </summary>
+/// <remarks>
+/// To get an instance of this type, use <see cref="Extensions.StringExtensions.EnumerateSplitSubstrings(ReadOnlySpan{char}, string[], StringSplitOptions)"/>.
+/// </remarks>
+public ref struct StringSplitByStringArrayEnumerator
+{
+    private readonly string[] _sep;
+    private readonly bool _onlyWhitespace;
+    private readonly StringSplitOptions _options;
+
+    private ReadOnlySpan<char> _remaining;
+    private bool _yieldEmpty;
+    private bool _returnOnce;
+
+    internal StringSplitByStringArrayEnumerator(
+        ReadOnlySpan<char> str,
+        string[] sep,
+        StringSplitOptions options)
+    {
+        _options = options;
+        _remaining = str;
+        _yieldEmpty = false;
+        _returnOnce = false;
+        _onlyWhitespace = false;
+        Current = default;
+
+        if (sep is null || sep.Length == 0)
+        {
+            _sep = StringSplitUtils.EmptyStringArray;
+            _onlyWhitespace = true;
+        }
+        else
+        {
+            if (sep.All(string.IsNullOrEmpty))
+            {
+                _returnOnce = true;
+                _sep = StringSplitUtils.EmptyStringArray;
+            }
+            else
+            {
+                _sep = sep;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the current substring
+    /// </summary>
+    public ReadOnlySpan<char> Current { get; private set; }
+
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
+    public readonly StringSplitByStringArrayEnumerator GetEnumerator() => this;
+
+    /// <summary>
+    /// Advances the enumerator to the next substring in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next substring; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
+    public bool MoveNext()
+    {
+        if (_returnOnce)
+        {
+            Current = _remaining;
+            _returnOnce = false;
+            _remaining = default;
+            return true;
+        }
+
+        var span = _remaining;
+        var options = _options;
+        var yieldEmpty = _yieldEmpty;
+
+        while (StringSplitUtils.TryMoveNext(
+            ref span,
+            ref yieldEmpty,
+            GetIndex(in span, out var sepLen),
+            sepLen,
+            options,
+            out var next))
+        {
+            if (_options.HasFlag(StringSplitOptions.RemoveEmptyEntries) && next.IsEmpty)
+            {
+                continue;
+            }
+
+            Current = next;
+            _remaining = span;
+            _yieldEmpty = yieldEmpty;
+            return true;
+        }
+
+        _yieldEmpty = yieldEmpty;
+        _remaining = span;
+        return false;
+    }
+
+    private readonly int GetIndex(in ReadOnlySpan<char> span, out int separatorLength)
+    {
+        if (_onlyWhitespace)
+        {
+            separatorLength = 1;
+            return span.IndexOfAny(StringSplitUtils.WhitespaceChars);
+        }
+
+        // TODO: Can this be optimized?
+        var found = false;
+        var minIndex = int.MaxValue;
+        separatorLength = 0;
+
+        var searchWindow = span;
+
+        foreach (var sep in _sep)
+        {
+            // will not find the match
+            if (sep.Length > searchWindow.Length)
+            {
+                continue;
+            }
+
+            var current = searchWindow.IndexOf(sep.AsSpan());
+
+            if (current > -1 && current < minIndex)
+            {
+                found = true;
+                minIndex = current;
+                separatorLength = sep.Length;
+            }
+        }
+
+        if (found)
+        {
+            return minIndex;
+        }
+
+        return -1;
+    }
+}

--- a/src/SpanUtils/Enumerators/StringSplitByStringEnumerator.cs
+++ b/src/SpanUtils/Enumerators/StringSplitByStringEnumerator.cs
@@ -1,0 +1,99 @@
+﻿using System;
+
+namespace SpanUtils.Enumerators;
+
+/// <summary>
+/// Enumerates substrings of a <see cref="ReadOnlySpan{Char}"/> separated by specified delimiting characters and options.
+/// </summary>
+/// <remarks>
+/// To get an instance of this type, use <see cref="Extensions.StringExtensions.EnumerateSplitSubstrings(ReadOnlySpan{char}, string, StringSplitOptions)"/>.
+/// </remarks>
+public ref struct StringSplitByStringEnumerator
+{
+    private readonly ReadOnlySpan<char> _sep;
+    private readonly StringSplitOptions _options;
+
+    private ReadOnlySpan<char> _remaining;
+    private bool _yieldEmpty;
+    private bool _returnOnce;
+
+    internal StringSplitByStringEnumerator(
+        ReadOnlySpan<char> str,
+        string sep,
+        StringSplitOptions options)
+    {
+        _options = options;
+        _remaining = str;
+        _yieldEmpty = false;
+        Current = default;
+
+        // Empty separator or longer separator than string -> return only the original string
+        if (string.IsNullOrEmpty(sep) || sep.Length > str.Length)
+        {
+            _sep = default;
+            _returnOnce = true;
+        }
+        else
+        {
+            _sep = sep.AsSpan();
+            _returnOnce = false;
+        }
+    }
+
+    /// <summary>
+    /// Gets the current substring
+    /// </summary>
+    public ReadOnlySpan<char> Current { get; private set; }
+
+    /// <summary>
+    /// Returns this instance as an enumerator.
+    /// </summary>
+    public readonly StringSplitByStringEnumerator GetEnumerator() => this;
+
+    /// <summary>
+    /// Advances the enumerator to the next substring in the span.
+    /// </summary>
+    /// <returns>
+    /// True if the enumerator successfully advanced to the next substring; false if
+    /// the enumerator has advanced past the end of the span.
+    /// </returns>
+    public bool MoveNext()
+    {
+        if (_returnOnce)
+        {
+            Current = _remaining;
+            _returnOnce = false;
+            _remaining = default;
+            return true;
+        }
+
+        var span = _remaining;
+        var sep = _sep;
+        var len = _sep.Length;
+        var options = _options;
+        var empty = _yieldEmpty;
+
+        while (StringSplitUtils.TryMoveNext(
+            ref span,
+            ref empty,
+            span.IndexOf(sep),
+            len,
+            options,
+            out var next))
+        {
+            if (_options.HasFlag(StringSplitOptions.RemoveEmptyEntries) && next.IsEmpty)
+            {
+                continue;
+            }
+
+            Current = next;
+            _remaining = span;
+            _yieldEmpty = empty;
+            return true;
+        }
+
+        _yieldEmpty = empty;
+        _remaining = span;
+        return false;
+    }
+}

--- a/src/SpanUtils/Enumerators/StringSplitUtils.cs
+++ b/src/SpanUtils/Enumerators/StringSplitUtils.cs
@@ -1,0 +1,147 @@
+﻿using System;
+
+namespace SpanUtils.Enumerators;
+
+internal static class StringSplitUtils
+{
+    public static bool TryMoveNext(
+        scoped ref ReadOnlySpan<char> remaining,
+        scoped ref bool yieldEmpty,
+        int index,
+        int stride,
+        StringSplitOptions options,
+        out ReadOnlySpan<char> next)
+    {
+        if (yieldEmpty)
+        {
+            yieldEmpty = false;
+            next = default;
+            return true;
+        }
+
+        var span = remaining;
+        var len = span.Length;
+
+        if (len == 0)
+        {
+            next = default;
+            remaining = default;
+            return false;
+        }
+
+        ReadOnlySpan<char> content;
+
+#pragma warning disable IDE0057 // Use range operator
+        if (index == -1)
+        {
+            content = span;
+            remaining = default;
+        }
+        else
+        {
+            content = span.Slice(0, index);
+            remaining = span.Slice(index + stride);
+            // Check if we have a trailing separator
+            if (remaining.Length == 0)
+            {
+                var separator = span.Slice(index, stride);
+                yieldEmpty = separator.Length > 0;
+            }
+        }
+#pragma warning restore IDE0057 // Use range operator
+
+#if NET5_0_OR_GREATER
+        if (options.HasFlag(StringSplitOptions.TrimEntries))
+        {
+            content = content.Trim();
+        }
+#else
+        _ = options;
+#endif
+
+        next = content;
+        return true;
+    }
+
+    public static readonly string[] EmptyStringArray = Array.Empty<string>();
+
+    public static readonly char[] NewlineChars = new[]
+    {
+        '\n', // LINE FEED (U+000A)
+        '\r', // CARRIAGE RETURN (U+000D)
+        '\f', // FORM FEED (U+000C)
+        '\u2028', // LINE SEPARATOR (U+2028)
+        '\u0085', // NEXT LINE (U+0085)
+        '\u2029', // PARAGRAPH SEPARATOR (U+2029)
+    };
+
+    public static readonly string[] NewLineStrings = new[]
+    {
+        "\r\n", // CARRIAGE RETURN (U+000D) + LINE FEED (U+000A)
+        "\n", // LINE FEED (U+000A)
+        "\r", // CARRIAGE RETURN (U+000D)
+        "\f", // FORM FEED (U+000C)
+        "\u2028", // LINE SEPARATOR (U+2028)
+        "\u0085", // NEXT LINE (U+0085)
+        "\u2029", // PARAGRAPH SEPARATOR (U+2029)
+    };
+
+    public static readonly string[] WhitespaceStrings = new[]
+    {
+        " ", // SPACE (U+0020)
+        "\u00A0", // NO-BREAK SPACE (U+00A0)
+        "\u1680", // OGHAM SPACE MARK (U+1680)
+        "\u2000", // EN QUAD (U+2000)
+        "\u2001", // EM QUAD (U+2001)
+        "\u2002", // EN SPACE (U+2002)
+        "\u2003", // EM SPACE (U+2003)
+        "\u2004", // THREE-PER-EM SPACE (U+2004)
+        "\u2005", // FOUR-PER-EM SPACE (U+2005)
+        "\u2006", // SIX-PER-EM SPACE (U+2006)
+        "\u2007", // FIGURE SPACE (U+2007)
+        "\u2008", // PUNCTUATION SPACE (U+2008)
+        "\u2009", // THIN SPACE (U+2009)
+        "\u200A", // HAIR SPACE (U+200A)
+        "\u2028", // LINE SEPARATOR (U+2028)
+        "\u2029", // PARAGRAPH SEPARATOR (U+2029)
+        "\u202F", // NARROW NO-BREAK SPACE (U+202F)
+        "\u205F", // MEDIUM MATHEMATICAL SPACE (U+205F)
+        "\u3000", // IDEOGRAPHIC SPACE (U+3000)
+        "\t", // CHARACTER TABULATION (U+0009)
+        "\n", // LINE FEED (U+000A)
+        "\u000B", // LINE TABULATION (U+000B)
+        "\f", // FORM FEED (U+000C)
+        "\r", // CARRIAGE RETURN (U+000D)
+        "\u0085", // NEXT LINE (U+0085)
+    };
+
+    // https://learn.microsoft.com/en-us/dotnet/api/system.char.iswhitespace?view=net-7.0#remarks
+    public static readonly char[] WhitespaceChars = new[]
+    {
+        ' ', // SPACE (U+0020)
+        '\u00A0', // NO-BREAK SPACE (U+00A0)
+        '\u1680', // OGHAM SPACE MARK (U+1680)
+        '\u2000', // EN QUAD (U+2000)
+        '\u2001', // EM QUAD (U+2001)
+        '\u2002', // EN SPACE (U+2002)
+        '\u2003', // EM SPACE (U+2003)
+        '\u2004', // THREE-PER-EM SPACE (U+2004)
+        '\u2005', // FOUR-PER-EM SPACE (U+2005)
+        '\u2006', // SIX-PER-EM SPACE (U+2006)
+        '\u2007', // FIGURE SPACE (U+2007)
+        '\u2008', // PUNCTUATION SPACE (U+2008)
+        '\u2009', // THIN SPACE (U+2009)
+        '\u200A', // HAIR SPACE (U+200A)
+        '\u2028', // LINE SEPARATOR (U+2028)
+        '\u2029', // PARAGRAPH SEPARATOR (U+2029)
+        '\u202F', // NARROW NO-BREAK SPACE (U+202F)
+        '\u205F', // MEDIUM MATHEMATICAL SPACE (U+205F)
+        '\u3000', // IDEOGRAPHIC SPACE (U+3000)
+        '\t', // CHARACTER TABULATION (U+0009)
+        '\n', // LINE FEED (U+000A)
+        '\u000B', // LINE TABULATION (U+000B)
+        '\f', // FORM FEED (U+000C)
+        '\r', // CARRIAGE RETURN (U+000D)
+        '\u0085', // NEXT LINE (U+0085)
+    };
+}

--- a/src/SpanUtils/Extensions/ReadOnlySpanChunksExtensions.cs
+++ b/src/SpanUtils/Extensions/ReadOnlySpanChunksExtensions.cs
@@ -46,4 +46,25 @@ public static class ReadOnlySpanChunksExtensions
     /// <returns>Enumerator which yields the chunks.</returns>
     public static ReadOnlySpanChunksEnumerator<T> GetReadOnlyChunksEnumerator<T>(this ReadOnlySpan<T> source, int size, bool exact) =>
         new(source, size, exact);
+
+    /// <summary>
+    /// Enumerate read-only chunks inside the given source
+    /// </summary>
+    /// <typeparam name="T">Type of values</typeparam>
+    /// <param name="source">Source values to enumerate</param>
+    /// <param name="size">Size of each chunk</param>
+    /// <returns>Enumerator which yields the chunks.</returns>
+    public static ReadOnlySpanChunksEnumerator<T> GetReadOnlyChunksEnumerator<T>(this Span<T> source, int size) =>
+        new(source, size);
+
+    /// <summary>
+    /// Enumerate read-only chunks inside the given source
+    /// </summary>
+    /// <typeparam name="T">Type of values</typeparam>
+    /// <param name="source">Source values to enumerate</param>
+    /// <param name="size">Size of each chunk</param>
+    /// <param name="exact">Whether only chunks matching the exact size will be enumerated. Default is <c>true</c></param>
+    /// <returns>Enumerator which yields the chunks.</returns>
+    public static ReadOnlySpanChunksEnumerator<T> GetReadOnlyChunksEnumerator<T>(this Span<T> source, int size, bool exact) =>
+        new(source, size, exact);
 }

--- a/src/SpanUtils/Extensions/ReadOnlySpanChunksExtensions.cs
+++ b/src/SpanUtils/Extensions/ReadOnlySpanChunksExtensions.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace SpanUtils.Extensions;
 
+/// <summary>
+/// Extension methods for arrays, <see cref="ReadOnlySpan{T}"/> and <see cref="Span{T}"/>
+/// </summary>
 public static class ReadOnlySpanChunksExtensions
 {
     /// <summary>

--- a/src/SpanUtils/Extensions/ReadOnlySpanReverseExtensions.cs
+++ b/src/SpanUtils/Extensions/ReadOnlySpanReverseExtensions.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace SpanUtils.Extensions;
 
+/// <summary>
+/// Extension methods for arrays, <see cref="ReadOnlySpan{T}"/> and <see cref="Span{T}"/>
+/// </summary>
 public static class ReadOnlySpanReverseExtensions
 {
     /// <summary>

--- a/src/SpanUtils/Extensions/ReadOnlySpanReverseExtensions.cs
+++ b/src/SpanUtils/Extensions/ReadOnlySpanReverseExtensions.cs
@@ -22,4 +22,13 @@ public static class ReadOnlySpanReverseExtensions
     /// <returns>Enumerator which yields the values in reverse.</returns>
     public static ReadOnlySpanReverseEnumerator<T> GetReadOnlyReverseEnumerator<T>(this ReadOnlySpan<T> source) =>
         new(source);
+
+    /// <summary>
+    /// Enumerate the contents of the source in reverse.
+    /// </summary>
+    /// <typeparam name="T">Type of values</typeparam>
+    /// <param name="source">Source to enumerate</param>
+    /// <returns>Enumerator which yields the values in reverse.</returns>
+    public static ReadOnlySpanReverseEnumerator<T> GetReadOnlyReverseEnumerator<T>(this Span<T> source) =>
+        new(source);
 }

--- a/src/SpanUtils/Extensions/ReadOnlySpanSelectExtensions.cs
+++ b/src/SpanUtils/Extensions/ReadOnlySpanSelectExtensions.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace SpanUtils.Extensions;
 
+/// <summary>
+/// Extension methods for arrays, <see cref="ReadOnlySpan{T}"/> and <see cref="Span{T}"/>
+/// </summary>
 public static class ReadOnlySpanSelectExtensions
 {
     /// <summary>

--- a/src/SpanUtils/Extensions/ReadOnlySpanSelectExtensions.cs
+++ b/src/SpanUtils/Extensions/ReadOnlySpanSelectExtensions.cs
@@ -24,4 +24,13 @@ public static class ReadOnlySpanSelectExtensions
     /// <returns>Enumerator which maps the values contained in the source with the given selector</returns>
     public static ReadOnlySpanSelectEnumerator<T, U> GetReadOnlySelectEnumerator<T, U>(this ReadOnlySpan<T> source, Func<T, U> selector) =>
         new(source, selector);
+
+    /// <summary>
+    /// Enumerate over the source by mapping values with the given function
+    /// </summary>
+    /// <typeparam name="T">Input type</typeparam>
+    /// <typeparam name="U">Output type</typeparam>
+    /// <returns>Enumerator which maps the values contained in the source with the given selector</returns>
+    public static ReadOnlySpanSelectEnumerator<T, U> GetReadOnlySelectEnumerator<T, U>(this Span<T> source, Func<T, U> selector) =>
+        new(source, selector);
 }

--- a/src/SpanUtils/Extensions/ReadOnlySpanWindowsExtensions.cs
+++ b/src/SpanUtils/Extensions/ReadOnlySpanWindowsExtensions.cs
@@ -24,4 +24,14 @@ public static class ReadOnlySpanWindowsExtensions
     /// <returns>Enumerator which yields the sliding windows.</returns>
     public static ReadOnlySpanWindowsEnumerator<T> GetReadOnlyWindowsEnumerator<T>(this ReadOnlySpan<T> source, int size) =>
         new(source, size);
+
+    /// <summary>
+    /// Enumerate read-only sliding windows inside the source
+    /// </summary>
+    /// <typeparam name="T">Type of values</typeparam>
+    /// <param name="source">Source values to enumerate</param>
+    /// <param name="size">Size of each sliding window</param>
+    /// <returns>Enumerator which yields the sliding windows.</returns>
+    public static ReadOnlySpanWindowsEnumerator<T> GetReadOnlyWindowsEnumerator<T>(this Span<T> source, int size) =>
+        new(source, size);
 }

--- a/src/SpanUtils/Extensions/ReadOnlySpanWindowsExtensions.cs
+++ b/src/SpanUtils/Extensions/ReadOnlySpanWindowsExtensions.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace SpanUtils.Extensions;
 
+/// <summary>
+/// Extension methods for arrays, <see cref="ReadOnlySpan{T}"/> and <see cref="Span{T}"/>
+/// </summary>
 public static class ReadOnlySpanWindowsExtensions
 {
     /// <summary>

--- a/src/SpanUtils/Extensions/SpanChunksExtensions.cs
+++ b/src/SpanUtils/Extensions/SpanChunksExtensions.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace SpanUtils.Extensions;
 
+/// <summary>
+/// Extension methods for arrays, <see cref="ReadOnlySpan{T}"/> and <see cref="Span{T}"/>
+/// </summary>
 public static class SpanChunksExtensions
 {
     /// <summary>

--- a/src/SpanUtils/Extensions/SpanReverseExtensions.cs
+++ b/src/SpanUtils/Extensions/SpanReverseExtensions.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace SpanUtils.Extensions;
 
+/// <summary>
+/// Extension methods for arrays, <see cref="ReadOnlySpan{T}"/> and <see cref="Span{T}"/>
+/// </summary>
 public static class SpanReverseExtensions
 {
     /// <summary>

--- a/src/SpanUtils/Extensions/SpanWindowsExtensions.cs
+++ b/src/SpanUtils/Extensions/SpanWindowsExtensions.cs
@@ -3,6 +3,9 @@ using System;
 
 namespace SpanUtils.Extensions;
 
+/// <summary>
+/// Extension methods for arrays, <see cref="ReadOnlySpan{T}"/> and <see cref="Span{T}"/>
+/// </summary>
 public static class SpanWindowsExtensions
 {
     /// <summary>

--- a/src/SpanUtils/Extensions/StringExtensions.cs
+++ b/src/SpanUtils/Extensions/StringExtensions.cs
@@ -1,0 +1,163 @@
+﻿using SpanUtils.Enumerators;
+using System;
+
+namespace SpanUtils.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="string"/>, <see cref="ReadOnlySpan{Char}"/> and <see cref="Span{Char}"/>
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    /// Returns an enumeration of lines in the provided string.
+    /// </summary>
+    /// <param name="input">A string containing lines to enumerate.</param>
+    /// <returns>An enumeration of lines.</returns>
+    public static StringSplitByLinesEnumerator EnumerateSplitLines(this string input) =>
+        new(input.AsSpan());
+
+    /// <summary>
+    /// Returns an enumeration of lines in the provided span.
+    /// </summary>
+    /// <param name="input">A span containing lines to enumerate.</param>
+    /// <returns>An enumeration of lines.</returns>
+    public static StringSplitByLinesEnumerator EnumerateSplitLines(this ReadOnlySpan<char> input) =>
+        new(input);
+
+    /// <summary>
+    /// Returns an enumeration of lines in the provided span.
+    /// </summary>
+    /// <param name="input">A span containing lines to enumerate.</param>
+    /// <returns>An enumeration of lines.</returns>
+    public static StringSplitByLinesEnumerator EnumerateSplitLines(this Span<char> input) =>
+        new(input);
+
+    #region Char
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified separator and based on the given options.
+    /// </summary>
+    /// <param name="input">A string to enumerate.</param>
+    /// <param name="separator">A character that delimits the substrings in this string.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by <paramref name="separator"/></returns>
+    public static StringSplitByCharEnumerator EnumerateSplitSubstrings(this string input, char separator, StringSplitOptions options) =>
+        new(input.AsSpan(), separator, options);
+
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified separator and based on the given options.
+    /// </summary>
+    /// <param name="input">A span to enumerate.</param>
+    /// <param name="separator">A character that delimits the substrings in this string.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by <paramref name="separator"/></returns>
+    public static StringSplitByCharEnumerator EnumerateSplitSubstrings(this ReadOnlySpan<char> input, char separator, StringSplitOptions options) =>
+        new(input, separator, options);
+
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified separator and based on the given options.
+    /// </summary>
+    /// <param name="input">A span to enumerate.</param>
+    /// <param name="separator">A character that delimits the substrings in this string.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by <paramref name="separator"/></returns>
+    public static StringSplitByCharEnumerator EnumerateSplitSubstrings(this Span<char> input, char separator, StringSplitOptions options) =>
+        new(input, separator, options);
+    #endregion
+
+    #region CharArray
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified separator.
+    /// </summary>
+    /// <param name="input">A string to enumerate.</param>
+    /// <param name="separator">An array of characters that delimit the substrings in this string or an empty array.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by one or more characters in <paramref name="separator"/></returns>
+    public static StringSplitByCharArrayEnumerator EnumerateSplitSubstrings(this string input, char[] separator, StringSplitOptions options) =>
+        new(input.AsSpan(), separator, options);
+
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified separator and based on the given options.
+    /// </summary>
+    /// <param name="input">A span to enumerate.</param>
+    /// <param name="separator">An array of characters that delimit the substrings in this string or an empty array.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by one or more characters in <paramref name="separator"/></returns>
+    public static StringSplitByCharArrayEnumerator EnumerateSplitSubstrings(this ReadOnlySpan<char> input, char[] separator, StringSplitOptions options) =>
+        new(input, separator, options);
+
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified separator and based on the given options.
+    /// </summary>
+    /// <param name="input">A span to enumerate.</param>
+    /// <param name="separator">An array of characters that delimit the substrings in this string or an empty array.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by one or more characters in <paramref name="separator"/></returns>
+    public static StringSplitByCharArrayEnumerator EnumerateSplitSubstrings(this Span<char> input, char[] separator, StringSplitOptions options) =>
+        new(input, separator, options);
+    #endregion
+
+    #region String
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified separator and based on the given options.
+    /// </summary>
+    /// <param name="input">A string to enumerate.</param>
+    /// <param name="separator">A string that delimits the substrings in this string.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by <paramref name="separator"/></returns>
+    public static StringSplitByStringEnumerator EnumerateSplitSubstrings(this string input, string separator, StringSplitOptions options) =>
+        new(input.AsSpan(), separator, options);
+
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified separator and based on the given options.
+    /// </summary>
+    /// <param name="input">A span to enumerate.</param>
+    /// <param name="separator">A string that delimits the substrings in this string.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by <paramref name="separator"/></returns>
+    public static StringSplitByStringEnumerator EnumerateSplitSubstrings(this ReadOnlySpan<char> input, string separator, StringSplitOptions options) =>
+        new(input, separator, options);
+
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified separator and based on the given options.
+    /// </summary>
+    /// <param name="input">A span to enumerate.</param>
+    /// <param name="separator">A string that delimits the substrings in this string.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by <paramref name="separator"/></returns>
+    public static StringSplitByStringEnumerator EnumerateSplitSubstrings(this Span<char> input, string separator, StringSplitOptions options) =>
+        new(input, separator, options);
+    #endregion
+
+    #region StringArray
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified delimiting strings and based on the given options.
+    /// </summary>
+    /// <param name="input">A string to enumerate.</param>
+    /// <param name="separator">An array of strings that delimit the substrings in this string or an empty array that contains no delimiters.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by one ore more strings in <paramref name="separator"/></returns>
+    public static StringSplitByStringArrayEnumerator EnumerateSplitSubstrings(this string input, string[] separator, StringSplitOptions options) =>
+        new(input.AsSpan(), separator, options);
+
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified delimiting strings and based on the given options.
+    /// </summary>
+    /// <param name="input">A span to enumerate.</param>
+    /// <param name="separator">An array of strings that delimit the substrings in this string or an empty array that contains no delimiters.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by one ore more strings in <paramref name="separator"/></returns>
+    public static StringSplitByStringArrayEnumerator EnumerateSplitSubstrings(this ReadOnlySpan<char> input, string[] separator, StringSplitOptions options) =>
+        new(input, separator, options);
+
+    /// <summary>
+    /// Returns an enumeration of substrings separated by specified delimiting strings and based on the given options.
+    /// </summary>
+    /// <param name="input">A span to enumerate.</param>
+    /// <param name="separator">An array of strings that delimit the substrings in this string or an empty array that contains no delimiters.</param>
+    /// <param name="options">A bitwise combination of the enumeration values that specifies whether to trim substrings and include empty substrings.</param>
+    /// <returns>An enumeration of substrings that are delimited by one ore more strings in <paramref name="separator"/></returns>
+    public static StringSplitByStringArrayEnumerator EnumerateSplitSubstrings(this Span<char> input, string[] separator, StringSplitOptions options) =>
+        new(input, separator, options);
+    #endregion
+}
+

--- a/src/SpanUtils/Properties/InternalsVisibleTo.cs
+++ b/src/SpanUtils/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SpanUtils.Tests")]

--- a/src/SpanUtils/SpanUtils.csproj
+++ b/src/SpanUtils/SpanUtils.csproj
@@ -28,7 +28,7 @@
 
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <!-- If all members are not documented, you can disable the compiler warnings -->
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <!--<NoWarn>$(NoWarn);CS1591</NoWarn>-->
 
     <UseReproducibleBuild Condition="'$(UseReproducibleBuild)'==''">false</UseReproducibleBuild>
   </PropertyGroup>

--- a/tests/SpanUtils.Tests/StringSplitTests.cs
+++ b/tests/SpanUtils.Tests/StringSplitTests.cs
@@ -1,0 +1,266 @@
+﻿using SpanUtils.Extensions;
+
+namespace SpanUtils.Tests;
+
+public class StringSplitTests
+{
+    public static readonly StringSplitOptions[] SplitOptions = new[]
+    {
+        StringSplitOptions.None,
+        StringSplitOptions.RemoveEmptyEntries,
+#if NET5_0_OR_GREATER
+        StringSplitOptions.TrimEntries,
+        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries,
+#endif
+    };
+
+    public static TheoryData<string, T, StringSplitOptions> MakeTestCases<T>((string, T)[] input)
+    {
+        var data = new TheoryData<string, T, StringSplitOptions>();
+
+        foreach (var option in SplitOptions)
+        {
+            foreach (var (lhs, rhs) in input)
+            {
+                data.Add(lhs, rhs, option);
+            }
+        }
+
+        return data;
+    }
+
+    public static readonly (string, char)[] CharTestData = new (string, char)[]
+    {
+        (";", ';' ),
+        (";;", ';' ),
+        (";;;", ';' ),
+        (";;;;;;;;;;;;;;", ';' ),
+        ("apple, orange, banana, peach", ',' ),
+        ("one;two;three;four", ';' ),
+        ("hello||world||from||C#", '|' ),
+        ("2023-04-01T12:30:00",  '-'),
+        ("2023-04-01T12:30:00",  'T'),
+        ("2023-04-01T12:30:00",  ':' ),
+        ("newline\nseparated\nvalues", '\n' ),
+        ("tabs\tare\tseparated", '\t'),
+        ("mixed separators, and; different|lengths", ',' ),
+        ("mixed separators, and; different|lengths",  ';'),
+        ("mixed separators, and; different|lengths", '|' ),
+        ("empty;;separators;are;;here;", ';' ),
+        ("multiple delimiters,,, in a row;;; test", ',' ),
+        ("multiple delimiters,,, in a row;;; test", ';' ),
+        ("spaces and tabs\tare tricky", ' ' ),
+        ("spaces and tabs\tare tricky", '\t' ),
+        ("special\ncharacters\r\nand line\rbreaks", '\n' ),
+        ("special\ncharacters\r\nand line\rbreaks", '\r' ),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", ';'),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", '|'),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", ';'),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", '|' ),
+        ("The handsome, energetic, young dog was playing with his smaller, more lethargic litter mate.", ','),
+        ("The handsome, energetic, young dog was playing with his smaller, more lethargic litter mate.", '.'),
+        ("; ; hello ; world ;; works ; ; again ; ; ;;", ';'),
+    };
+
+    public static readonly TheoryData<string, char, StringSplitOptions> CharTestCases = MakeTestCases(CharTestData);
+
+    [Theory]
+    [MemberData(nameof(CharTestCases))]
+    public void CharSplittingWorksAsExpected(string input, char split, StringSplitOptions options)
+    {
+        var parts = new List<string>();
+
+        foreach (ReadOnlySpan<char> content in input.EnumerateSplitSubstrings(split, options))
+        {
+            parts.Add(content.ToString());
+        }
+
+        var actualSplit = input.Split(new[] { split }, options);
+
+        parts.Should().BeEquivalentTo(actualSplit);
+    }
+
+    public static readonly (string, char[])[] CharArrayTestData = new (string, char[])[]
+    {
+        (";", new[] { ';' } ),
+        (";;", new[] { ';' } ),
+        (";;;", new[] { ';' } ),
+        (";;;;;;;;;;;;;;", new[] { ';' } ),
+        ("-_aa-_", new[] { '-', '_' } ),
+        ("apple, orange, banana, peach", new[] { ',' }),
+        ("one;two;three;four", new[] { ';' }),
+        ("hello||world||from||C#", new[] { '|' }),
+        ("2023-04-01T12:30:00", new[] { '-', 'T', ':' }),
+        ("newline\nseparated\nvalues", new[] { '\n' }),
+        ("tabs\tare\tseparated", new[] { '\t' }),
+        ("mixed separators, and; different|lengths", new[] { ',', ';', '|' }),
+        ("empty;;separators;are;;here;", new[] { ';' }),
+        ("multiple delimiters,,, in a row;;; test", new[] { ',', ';' }),
+        ("spaces and tabs\tare tricky", new[] { ' ', '\t' }),
+        ("special\ncharacters\r\nand line\rbreaks", new[] { '\n', '\r' }),
+        ("\r\nspecial\r\n\ncharacters\r\nand line\rbreaks\n\r\n", new[] { '\n', '\r' }),
+        ("empty array\rsplits\n\nby whitespace\tand\fworks", Array.Empty<char>()),
+        ("x\fand\r\n xx \t\r\f\n\r\n afaf \r\n tes special\ncharacters\r\nand line\rbreaks\r end ", Array.Empty<char>()),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", new[] { ';', '|', ';', '|' }),
+        (";;foo;b4||a4;;bar;;baz;;;b4||a4;buz|;;||;<", new[] { ';', '|', ';',  '|', '<' }),
+        ("The handsome, energetic, young dog was playing with his smaller, more lethargic litter mate.", new[] { ',', '.', '!', '?', ';', ':', ' ' }),
+        ("; | ; || hello| ; | | ;|world ;|works ;again| ; || ;", new[] { ';', '|'}),
+        ("; ; hello ; world ;; works ; ; again ; ; ;;", new[] { ';' }),
+        ("; ; hello ; world ;; works ; ; again ; ; ;;", new[] { ';', ' ' }),
+    };
+
+    public static readonly TheoryData<string, char[], StringSplitOptions> CharArrayCases = MakeTestCases(CharArrayTestData);
+
+    [Theory]
+    [MemberData(nameof(CharArrayCases))]
+    public void CharArraySplittingWorksAsExpected(string input, char[] split, StringSplitOptions options)
+    {
+        var parts = new List<string>();
+
+        foreach (ReadOnlySpan<char> content in input.EnumerateSplitSubstrings(split, options))
+        {
+            parts.Add(content.ToString());
+        }
+
+        var actualSplit = input.Split(split, options);
+
+        parts.Should().BeEquivalentTo(actualSplit);
+    }
+
+    public static readonly (string, string)[] StringTestData = new (string, string)[]
+    {
+        (";", ";" ),
+        (";;", ";" ),
+        (";;;", ";" ),
+        (";;;;;;;;;;;;;;", ";" ),
+        ("apple, orange, banana, peach", "," ),
+        ("apple, orange, banana, peach", ", " ),
+        ("apple, orange, banana, peach", " " ),
+        ("apple, orange, banana, peach", "" ),
+        ("apple, orange, banana, peach", "is not found" ),
+        ("apple, orange, banana, peach", "longer than apple, orange, banana, peach" ),
+        ("one;two;three;four", ";" ),
+        ("hello||world||from||C#", "|" ),
+        ("2023-04-01T12:30:00",  "-"),
+        ("2023-04-01T12:30:00",  "T"),
+        ("2023-04-01T12:30:00",  ":" ),
+        ("newline\nseparated\nvalues", "\n" ),
+        ("tabs\tare\tseparated", "\t"),
+        ("mixed separators, and; different|lengths", "," ),
+        ("mixed separators, and; different|lengths",  ";"),
+        ("mixed separators, and; different|lengths", "|" ),
+        ("empty;;separators;are;;here;", ";" ),
+        ("multiple delimiters,,, in a row;;; test", "," ),
+        ("multiple delimiters,,, in a row;;; test", ";" ),
+        ("spaces and tabs\tare tricky", " " ),
+        ("spaces and tabs\tare tricky", "\t" ),
+        ("special\ncharacters\r\nand line\rbreaks", "\n" ),
+        ("special\ncharacters\r\nand line\rbreaks", "\r" ),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", ";"),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", "|"),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", ";"),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", "|" ),
+        ("The handsome, energetic, young dog was playing with his smaller, more lethargic litter mate.", ","),
+        ("The handsome, energetic, young dog was playing with his smaller, more lethargic litter mate.", "."),
+        ("; ; hello ; world ;; works ; ; again ; ; ;;", ";"),
+    };
+
+    public static readonly TheoryData<string, string, StringSplitOptions> StringTestCases = MakeTestCases(StringTestData);
+
+    [Theory]
+    [MemberData(nameof(StringTestCases))]
+    public void StringSplittingWorksAsExpected(string input, string split, StringSplitOptions options)
+    {
+        var parts = new List<string>();
+
+        foreach (ReadOnlySpan<char> content in input.EnumerateSplitSubstrings(split, options))
+        {
+            parts.Add(content.ToString());
+        }
+
+        var actualSplit = input.Split(new[] { split }, options);
+
+        parts.Should().BeEquivalentTo(actualSplit);
+    }
+
+    public static readonly (string, string[])[] StringArrayTestData = new[]
+    {
+        (";", new[] { ";" }),
+        (";;", new[] { ";" }),
+        (";;;", new[] { ";" }),
+        (";;;;;;;;;;;;;;", new[] { ";" }),
+        ("apple, orange, banana, peach", new[] { ", " }),
+        ("apple, orange, banana, peach", new[] { "" }),
+        ("apple, orange, banana, peach", new[] { "", "", }),
+        ("apple, orange, banana, peach", new[] { "", "", "", }),
+        ("apple, orange, banana, peach", Array.Empty<string>()),
+        ("apple, orange, banana, peach", new[] { "not found" }),
+        ("apple, orange, banana, peach", new[] { "longer than apple, orange, banana, peach" }),
+        ("apple, orange, banana, peach", new[] { "longer than apple, orange, banana, peach", ", " }),
+        ("one;two;three;four", new[] { ";" }),
+        ("hello||world||from||C#", new[] { "||" }),
+        ("2023-04-01T12:30:00", new[] { "-", "T", ":" }),
+        ("newline\nseparated\nvalues", new[] { "\n" }),
+        ("tabs\tare\tseparated", new[] { "\t" }),
+        ("mixed separators, and; different|lengths", new[] { ", ", "; ", "|" }),
+        ("empty;;separators;are;;here;", new[] { ";" }),
+        ("multiple delimiters,,, in a row;;; test", new[] { ",", ";" }),
+        ("spaces and tabs\tare tricky", new[] { " ", "\t" }),
+        ("special\ncharacters\r\nand line\rbreaks", new[] { "\n", "\r\n", "\r" }),
+        ("x\fand\r\n xx \t\r\f\n\r\n afaf \r\n tes special\ncharacters\r\nand line\rbreaks\r end ", Array.Empty<string>()),
+        ("foo;b4||a4;;bar;;baz;;;b4||a4;buz", new[] { ";", "||", ";;", ";;;", "|" }),
+        (";;foo;b4||a4;;bar;;baz;;;b4||a4;buz|;;||;<", new[] { ";", "||", ";;", ";;;", "|", "<" }),
+        ("The handsome, energetic, young dog was playing with his smaller, more lethargic litter mate.", new[] { ", ", " " }),
+        ("The handsome, energetic, young dog was playing with his smaller, more lethargic litter mate.", new[] { ",", ".", "!", "?", ";", ":", " " }),
+        ("; ; hello ; world ;; works ; ; again ; ; ;;", new[] { ";" }),
+        ("; ; hello ; world ;; works ; ; again ; ; ;;", new[] { ";", " " }),
+    };
+
+    public static readonly TheoryData<string, string[], StringSplitOptions> TestStringCases = MakeTestCases(StringArrayTestData);
+
+    [Theory]
+    [MemberData(nameof(TestStringCases))]
+    public void StringArraySplittingWorksAsExpected(string input, string[] split, StringSplitOptions options)
+    {
+        var parts = new List<string>();
+
+        foreach (ReadOnlySpan<char> content in input.EnumerateSplitSubstrings(split, options))
+        {
+            parts.Add(content.ToString());
+        }
+
+        var actualSplit = input.Split(split, options);
+
+        parts.Should().BeEquivalentTo(actualSplit);
+    }
+
+    public static readonly TheoryData<string> LinesTestCases = new()
+    {
+        "",
+        "no lines",
+        "x\rand\r\n xx \t\r\n\r\n afaf \r\n tes special\ncharacters\r\nand line\rbreaks\r end",
+        "supports\fvarous\rforms\nof\r\nnewlines\u2028and\u0085and\u2029yay",
+        @"
+this
+is a
+multi-line
+string
+",
+    };
+
+    [Theory]
+    [MemberData(nameof(LinesTestCases))]
+    public void StringLineSplittingWorksAsExpected(string input)
+    {
+        var parts = new List<string>();
+
+        foreach (ReadOnlySpan<char> content in input.EnumerateSplitLines())
+        {
+            parts.Add(content.ToString());
+        }
+
+        var actualSplit = input.Split(Enumerators.StringSplitUtils.NewLineStrings, default);
+
+        parts.Should().BeEquivalentTo(actualSplit);
+    }
+}


### PR DESCRIPTION
These new enumerators utilize ReadOnlySpans to allow enumeration of
delimited substrings inside the original string without allocating
additional strings.

+ Minor other minor additions